### PR TITLE
more clarification around plain-text

### DIFF
--- a/draft-iab-rfc-framework.txt
+++ b/draft-iab-rfc-framework.txt
@@ -4,12 +4,12 @@
 
 Internet Architecture Board                                  H. Flanagan
 Internet-Draft                                                RFC Editor
-Intended status: Informational                          February 2, 2016
-Expires: August 5, 2016
+Intended status: Informational                          February 5, 2016
+Expires: August 8, 2016
 
 
                           RFC Format Framework
-                       draft-iab-rfc-framework-03
+                       draft-iab-rfc-framework-04
 
 Abstract
 
@@ -47,13 +47,13 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on August 5, 2016.
+   This Internet-Draft will expire on August 8, 2016.
 
 
 
 
 
-Flanagan                 Expires August 5, 2016                 [Page 1]
+Flanagan                 Expires August 8, 2016                 [Page 1]
 
 Internet-Draft            RFC Format Framework             February 2016
 
@@ -82,38 +82,39 @@ Table of Contents
    5.  Key Changes . . . . . . . . . . . . . . . . . . . . . . . . .   6
    6.  Canonical Format Documents  . . . . . . . . . . . . . . . . .   6
      6.1.  XML for RFCs  . . . . . . . . . . . . . . . . . . . . . .   6
-   7.  Publication Format Documents  . . . . . . . . . . . . . . . .   7
-     7.1.  HTML  . . . . . . . . . . . . . . . . . . . . . . . . . .   7
+   7.  Publication Format Documents  . . . . . . . . . . . . . . . .   8
+     7.1.  HTML  . . . . . . . . . . . . . . . . . . . . . . . . . .   8
      7.2.  PDF . . . . . . . . . . . . . . . . . . . . . . . . . . .   8
-     7.3.  Plain Text  . . . . . . . . . . . . . . . . . . . . . . .   8
+     7.3.  Plain Text  . . . . . . . . . . . . . . . . . . . . . . .   9
      7.4.  Potential Future Publication Formats  . . . . . . . . . .   9
        7.4.1.  EPUB  . . . . . . . . . . . . . . . . . . . . . . . .   9
    8.  Figures and Artwork . . . . . . . . . . . . . . . . . . . . .   9
      8.1.  SVG . . . . . . . . . . . . . . . . . . . . . . . . . . .   9
-   9.  Content and Page Layout . . . . . . . . . . . . . . . . . . .   9
-     9.1.  Non-ASCII Characters  . . . . . . . . . . . . . . . . . .   9
+   9.  Content and Page Layout . . . . . . . . . . . . . . . . . . .  10
+     9.1.  Non-ASCII Characters  . . . . . . . . . . . . . . . . . .  10
      9.2.  Style Guide . . . . . . . . . . . . . . . . . . . . . . .  10
      9.3.  CSS Requirements  . . . . . . . . . . . . . . . . . . . .  10
    10. Transition Plan . . . . . . . . . . . . . . . . . . . . . . .  10
      10.1.  Statement of Work and RFP for Tool Development . . . . .  10
      10.2.  Testing and Transition . . . . . . . . . . . . . . . . .  10
-     10.3.  Completion . . . . . . . . . . . . . . . . . . . . . . .  11
+     10.3.  Completion . . . . . . . . . . . . . . . . . . . . . . .  12
    11. IANA Considerations . . . . . . . . . . . . . . . . . . . . .  12
    12. Security Considerations . . . . . . . . . . . . . . . . . . .  12
    13. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  12
    14. Appendix - Change log . . . . . . . . . . . . . . . . . . . .  12
-     14.1.  draft-iab-rfc-framework-02 to -03  . . . . . . . . . . .  12
-     14.2.  draft-iab-rfc-framework-01 to -02  . . . . . . . . . . .  12
-     14.3.  draft-iab-rfc-framework-00 to -01  . . . . . . . . . . .  12
-   15. References  . . . . . . . . . . . . . . . . . . . . . . . . .  13
+     14.1.  draft-iab-rfc-framework-03 to -04  . . . . . . . . . . .  12
+     14.2.  draft-iab-rfc-framework-02 to -03  . . . . . . . . . . .  13
+     14.3.  draft-iab-rfc-framework-01 to -02  . . . . . . . . . . .  13
+     14.4.  draft-iab-rfc-framework-00 to -01  . . . . . . . . . . .  13
 
 
 
-Flanagan                 Expires August 5, 2016                 [Page 2]
+Flanagan                 Expires August 8, 2016                 [Page 2]
 
 Internet-Draft            RFC Format Framework             February 2016
 
 
+   15. References  . . . . . . . . . . . . . . . . . . . . . . . . .  13
      15.1.  Normative References . . . . . . . . . . . . . . . . . .  13
      15.2.  Informative References . . . . . . . . . . . . . . . . .  14
    Author's Address  . . . . . . . . . . . . . . . . . . . . . . . .  15
@@ -134,7 +135,8 @@ Internet-Draft            RFC Format Framework             February 2016
 
    Key changes to the publication of RFCs are highlighted, and a
    transition plan that will take the Series from a plain-text, ASCII-
-   only format to the new formats is described [RFC-INTEREST].
+   only format to the new formats is described on the rfc-interest
+   mailing list [RFC-INTEREST].
 
    This document is concerned with the production of RFCs, focusing on
    the published formats.  It does not address any changes to the
@@ -160,15 +162,16 @@ Internet-Draft            RFC Format Framework             February 2016
    standards, best practices, and more for this global network that
    continues to grow.  In order to make RFCs easily viewable to the
    largest number of people possible, across a wide array of devices,
-   and to respect the diversity of authors and reference materials, it
-   is time to update the tightly prescribed format of the RFC Series.
 
 
 
-Flanagan                 Expires August 5, 2016                 [Page 3]
+Flanagan                 Expires August 8, 2016                 [Page 3]
 
 Internet-Draft            RFC Format Framework             February 2016
 
+
+   and to respect the diversity of authors and reference materials, it
+   is time to update the tightly prescribed format of the RFC Series.
 
    All changes to the format of the RFC Series must consider the
    requirements of a wide set of communities, over an extended length of
@@ -215,17 +218,16 @@ Internet-Draft            RFC Format Framework             February 2016
    list, as well as in several face-to-face sessions at IETF meetings.
    Regular conversations were held with the IETF, IRTF, IAB, and IAOC
    chairs, and the Independent Stream Editor, to discuss high-level
-   stream requirements.  Updates regarding the status of the project
-   were provided to the IETF community during the IETF Technical Plenary
 
 
 
-
-Flanagan                 Expires August 5, 2016                 [Page 4]
+Flanagan                 Expires August 8, 2016                 [Page 4]
 
 Internet-Draft            RFC Format Framework             February 2016
 
 
+   stream requirements.  Updates regarding the status of the project
+   were provided to the IETF community during the IETF Technical Plenary
    as well as Format BoFs or IAB sessions at IETF 84, IETF 85, IETF 88,
    IETF 89, and IETF 90 [IETF84] [IETF85] [IETF88] [IETF89] [IETF90].
 
@@ -271,17 +273,18 @@ Internet-Draft            RFC Format Framework             February 2016
    considered reasonable when responding to a subpoena request for an
    RFC.
 
-   Given that several other standards development organizations (SDOs)
-   do not offer plain-text documents, and in fact may offer more than
-   one format for their standards, informal input was sought from them
 
 
 
-Flanagan                 Expires August 5, 2016                 [Page 5]
+
+Flanagan                 Expires August 8, 2016                 [Page 5]
 
 Internet-Draft            RFC Format Framework             February 2016
 
 
+   Given that several other standards development organizations (SDOs)
+   do not offer plain-text documents, and in fact may offer more than
+   one format for their standards, informal input was sought from them
    regarding their experience with supporting one or more non-plain-text
    formats for their standards.
 
@@ -328,15 +331,15 @@ Internet-Draft            RFC Format Framework             February 2016
       necessary to render a variety of formats; any question about what
       was intended in the publication will be answered from this format.
 
-   o  Authors may submit drafts in xml2rfc v2 vocabulary, but the final
-      publication will convert that to xml2rfc v3 vocabulary.
 
 
-
-Flanagan                 Expires August 5, 2016                 [Page 6]
+Flanagan                 Expires August 8, 2016                 [Page 6]
 
 Internet-Draft            RFC Format Framework             February 2016
 
+
+   o  Authors may submit drafts in xml2rfc v2 vocabulary, but the final
+      publication will convert that to xml2rfc v3 vocabulary.
 
    o  SVG is supported and will be embedded in the final XML file.
 
@@ -353,8 +356,9 @@ Internet-Draft            RFC Format Framework             February 2016
       boilerplate as applicable at time of publication specified by RFC
       5741 or its successors [RFC5741].
 
-   o  The final XML will be self-contained.  For instance, all features
-      that reference externally-defined input will be expanded.  This
+   o  The final XML will be self-contained with all the information
+      known at publication time.  For instance, all features that
+      reference externally-defined input will be expanded.  This
       includes all uses of xinclude, src attributes (such as in
       <artwork> or <sourcecode> elements), include-like processing
       instructions, and externally defined entities.
@@ -379,6 +383,17 @@ Internet-Draft            RFC Format Framework             February 2016
    made in the publication process.  This draft, when published, will
    obsolete the RFC published from draft-iab-xml2rfcv2.
 
+
+
+
+
+
+
+Flanagan                 Expires August 8, 2016                 [Page 7]
+
+Internet-Draft            RFC Format Framework             February 2016
+
+
 7.  Publication Format Documents
 
 7.1.  HTML
@@ -386,18 +401,10 @@ Internet-Draft            RFC Format Framework             February 2016
    [I-D.iab-html-rfc] - Describes the semantic HTML that will be
    produced by the RFC Editor from the xml2rfc v3 files.
 
-
-
-
-Flanagan                 Expires August 5, 2016                 [Page 7]
-
-Internet-Draft            RFC Format Framework             February 2016
-
-
    Key points regarding the HTML output:
 
-   o  The HTML will not be derived from the plain-text publication
-      format.
+   o  The HTML will be rendered from the XML file; it will not be
+      derived from the plain-text publication format.
 
    o  The body of the document will use a subset of HTML.  The documents
       will include CSS for default visual presentation; it can be
@@ -423,8 +430,8 @@ Internet-Draft            RFC Format Framework             February 2016
 
    Key points regarding the PDF output:
 
-   o  The PDF file will not be derived from the plain-text publication
-      format.
+   o  The PDF file will be rendered from the XML file; it will not be
+      derived from the plain-text publication format.
 
    o  The PDF publication format will conform to the PDF/A-3 standard
       and will embed the canonical XML source.
@@ -435,6 +442,14 @@ Internet-Draft            RFC Format Framework             February 2016
    o  The PDF will include a rich set of tags and metadata within the
       document
 
+
+
+
+Flanagan                 Expires August 8, 2016                 [Page 8]
+
+Internet-Draft            RFC Format Framework             February 2016
+
+
    o  SVG is supported and will be included in the PDF file.
 
 7.3.  Plain Text
@@ -442,13 +457,6 @@ Internet-Draft            RFC Format Framework             February 2016
    [I-D.iab-rfc-plaintext] - Describes the details of the plain text
    format, focusing in particular on what is changing from the existing
    plain-text output.
-
-
-
-Flanagan                 Expires August 5, 2016                 [Page 8]
-
-Internet-Draft            RFC Format Framework             February 2016
-
 
    Key points regarding the plain-text output:
 
@@ -488,6 +496,16 @@ Internet-Draft            RFC Format Framework             February 2016
    XML-based vocabulary for creating line drawings; SVG information will
    be embedded within the canonical XML at time of publication.
 
+
+
+
+
+
+Flanagan                 Expires August 8, 2016                 [Page 9]
+
+Internet-Draft            RFC Format Framework             February 2016
+
+
 9.  Content and Page Layout
 
 9.1.  Non-ASCII Characters
@@ -497,14 +515,6 @@ Internet-Draft            RFC Format Framework             February 2016
    where and how non-ASCII characters may be used in an RFC, with an eye
    towards keeping the documents as secure and readable as possible
    given the information that needs to be expressed.
-
-
-
-
-Flanagan                 Expires August 5, 2016                 [Page 9]
-
-Internet-Draft            RFC Format Framework             February 2016
-
 
 9.2.  Style Guide
 
@@ -544,6 +554,14 @@ Internet-Draft            RFC Format Framework             February 2016
    approving bodies will select drafts to run through the proposed new
    publication process.  While the final RFCs published during this time
    will continue as plain-text and immutable once published, the
+
+
+
+Flanagan                 Expires August 8, 2016                [Page 10]
+
+Internet-Draft            RFC Format Framework             February 2016
+
+
    feedback process is necessary to bootstrap initial testing.  These
    early tests will target finding issues with the proposed xml2rfc v3
    vocabulary that result in poorly formed publication formats as well
@@ -554,14 +572,6 @@ Internet-Draft            RFC Format Framework             February 2016
    Center (RPC) spends on testing and QA, note that their priority is to
    edit and publish documents, community assistance will be necessary to
    help move this stage along.  A mailing list and experimental source
-
-
-
-Flanagan                 Expires August 5, 2016                [Page 10]
-
-Internet-Draft            RFC Format Framework             February 2016
-
-
    directory on the RFC Editor website will be created for community
    members willing to assist in the detailed review of the XML and
    publication formats.  Editorial checks of the publication formats by
@@ -584,6 +594,8 @@ Internet-Draft            RFC Format Framework             February 2016
    format, though they are strongly encouraged to do so; plain-text will
    also remain an option for the foreseeable future.  However, documents
    submitted as plain-text cannot include such features as SVG artwork.
+   The RPC will generate an XML file if necessary for basic processing
+   and subsequent rendering into the approved output formats.
 
    A known risk at this point of the transition is the difficulty in
    quantifying the resources required from the RPC.  This phase will
@@ -598,6 +610,14 @@ Internet-Draft            RFC Format Framework             February 2016
    Final success of the transition will be measured by the closure of
    all bugs which had been identified by the RPC and the Tools
    Development team as major or critical.  There must also be rough
+
+
+
+Flanagan                 Expires August 8, 2016                [Page 11]
+
+Internet-Draft            RFC Format Framework             February 2016
+
+
    consensus from the community regarding the utility of the new
    formats.
 
@@ -608,15 +628,6 @@ Internet-Draft            RFC Format Framework             February 2016
    and published with all available publication formats.  All authors
    will be expected to review the final documents as consistent with the
    evolving procedures for reviewing drafts.
-
-
-
-
-
-Flanagan                 Expires August 5, 2016                [Page 11]
-
-Internet-Draft            RFC Format Framework             February 2016
-
 
    Success for this phase will be measured by a solid understanding by
    the RSE and the IAOC of the necessary costs and resources required
@@ -646,15 +657,32 @@ Internet-Draft            RFC Format Framework             February 2016
 
    To be removed by RFC Editor
 
-14.1.  draft-iab-rfc-framework-02 to -03
+14.1.  draft-iab-rfc-framework-03 to -04
+
+   Introduction: editorial changes
+
+   Clarified that submitted plain text will be converted to XML by the
+   RPC; the XML will be used to render all output formats.
+
+
+
+
+
+
+Flanagan                 Expires August 8, 2016                [Page 12]
+
+Internet-Draft            RFC Format Framework             February 2016
+
+
+14.2.  draft-iab-rfc-framework-02 to -03
 
    HTML output: clarified expectations around use of JavaScript.
 
-14.2.  draft-iab-rfc-framework-01 to -02
+14.3.  draft-iab-rfc-framework-01 to -02
 
    Introduction: Removed some unnecessary history.
 
-14.3.  draft-iab-rfc-framework-00 to -01
+14.4.  draft-iab-rfc-framework-00 to -01
 
    Decision Making Process: noted taht other XML schemas and
    vocabularies were considered by the design team
@@ -663,16 +691,6 @@ Internet-Draft            RFC Format Framework             February 2016
 
    HTML: clarified that JavaScript should not impact readability of the
    document as it looked at time of publication
-
-
-
-
-
-
-Flanagan                 Expires August 5, 2016                [Page 12]
-
-Internet-Draft            RFC Format Framework             February 2016
-
 
 15.  References
 
@@ -705,6 +723,13 @@ Internet-Draft            RFC Format Framework             February 2016
               Series Output Document Format", draft-iab-rfc-use-of-
               pdf-01 (work in progress), January 2016.
 
+
+
+Flanagan                 Expires August 8, 2016                [Page 13]
+
+Internet-Draft            RFC Format Framework             February 2016
+
+
    [I-D.iab-rfc-plaintext]
               Flanagan, H., "Requirements for Plain-Text RFCs", draft-
               iab-rfc-plaintext-01 (work in progress), January 2016.
@@ -717,18 +742,6 @@ Internet-Draft            RFC Format Framework             February 2016
    [I-D.iab-rfc-css]
               Flanagan, H., "CSS Requirements for RFCs", draft-iab-rfc-
               css-00 (work in progress), January 2016.
-
-
-
-
-
-
-
-
-Flanagan                 Expires August 5, 2016                [Page 13]
-
-Internet-Draft            RFC Format Framework             February 2016
-
 
 15.2.  Informative References
 
@@ -766,6 +779,13 @@ Internet-Draft            RFC Format Framework             February 2016
    [IETF88]   Flanagan, H., "IETF 88 Proceedings: RFC Format (rfcform)",
               n.d., <http://www.ietf.org/proceedings/88/rfcform.html>.
 
+
+
+Flanagan                 Expires August 8, 2016                [Page 14]
+
+Internet-Draft            RFC Format Framework             February 2016
+
+
    [IETF89]   Flanagan, H., "IETF 89 Proceedings: RFC Format (rfcform)",
               n.d., <http://www.ietf.org/proceedings/89/rfcform.html>.
 
@@ -778,13 +798,6 @@ Internet-Draft            RFC Format Framework             February 2016
    [NDN2014]  "28th NORDUnet Conference 2014", 2014,
               <https://events.nordu.net/display/NORDU2014/
               BoF%27s+and+side+meetings>.
-
-
-
-Flanagan                 Expires August 5, 2016                [Page 14]
-
-Internet-Draft            RFC Format Framework             February 2016
-
 
    [RFC-INTEREST]
               RFC Editor, "rfc-interest -- A list for discussion of the
@@ -824,17 +837,4 @@ Author's Address
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-Flanagan                 Expires August 5, 2016                [Page 15]
+Flanagan                 Expires August 8, 2016                [Page 15]

--- a/draft-iab-rfc-framework.xml
+++ b/draft-iab-rfc-framework.xml
@@ -18,7 +18,7 @@
 
 ]>
 
-<rfc ipr="trust200902" docName="draft-iab-rfc-framework-03" category="info">
+<rfc ipr="trust200902" docName="draft-iab-rfc-framework-04" category="info">
 
 <?rfc toc="yes"?>
 
@@ -33,7 +33,7 @@
       </address>
     </author>
 
-    <date year="2016" month="February" day="2"/>
+    <date year="2016" month="February" day="5"/>
     
     <area>General</area>
 
@@ -62,7 +62,7 @@
 
 <t><xref target="RFC6949"/>, "RFC Series Format Requirements and Future Development," discussed the need for additional features within RFCs such as non-ASCII characters to respect author names, more advanced artwork than ASCII art, and documents that could display properly on a wide variety of devices.  Based on the discussions with the IETF community as well as other communities of interest, the RFC Series Editor decided to explore a change to the format of the Series <xref target="XML-ANNOUNCE"/>.  This document serves as the framework that describes the problems being solved and summarizes the documents created to-date that capture the specific requirements for each aspect of the change in format.  </t>
 
-<t>Key changes to the publication of RFCs are highlighted, and a transition plan that will take the Series from a plain-text, ASCII-only format to the new formats is described <xref target="RFC-INTEREST"/>.</t>
+<t>Key changes to the publication of RFCs are highlighted, and a transition plan that will take the Series from a plain-text, ASCII-only format to the new formats is described on the rfc-interest mailing list <xref target="RFC-INTEREST"/>.</t>
 
 <t>This document is concerned with the production of RFCs, focusing on the published formats. It does not address any changes to the processes each stream uses to develop and review their submissions (specifically, how Internet-Drafts will be developed).  While I-Ds have a similar set of issues and concerns, directly addressing those issues for I-Ds will be discussed within each document stream.</t>
 
@@ -151,7 +151,7 @@
   <t>The XML file will not contain any xml2rfc v3 vocabulary elements or attributes that have been marked deprecated. </t>
   <t>A Document Type Definition (DTD) will no longer be used. The grammar will be defined using RelaxNG.</t>
   <t>The final XML file will contain, verbatim, the appropriate boilerplate as applicable at time of publication specified by RFC 5741 or its successors <xref target="RFC5741"/>.</t>
-  <t>The final XML will be self-contained. For instance, all features that reference externally-defined input will be expanded. This includes all uses of xinclude, src attributes (such as in &lt;artwork&gt; or &lt;sourcecode&gt; elements), include-like processing instructions, and externally defined entities.</t>
+  <t>The final XML will be self-contained with all the information known at publication time. For instance, all features that reference externally-defined input will be expanded. This includes all uses of xinclude, src attributes (such as in &lt;artwork&gt; or &lt;sourcecode&gt; elements), include-like processing instructions, and externally defined entities.</t>
   <t>The final XML will not contain comments or processing instructions.</t>
   <t>The final XML will not contain src attributes for &lt;artwork&gt; or 
 &lt;sourcecode&gt; elements.</t>
@@ -171,7 +171,7 @@
 <t>Key points regarding the HTML output:</t>
 
 <t><list style='symbols'>
-  <t>The HTML will not be derived from the plain-text publication format.</t>
+  <t>The HTML will be rendered from the XML file; it will not be derived from the plain-text publication format.</t>
   <t>The body of the document will use a subset of HTML. The documents will include CSS for default visual presentation; it can be overwritten by a local CSS file.</t> 
   <t>SVG is supported and will be included in the HTML file.</t>
   <t>Text will be reflowable.</t>
@@ -186,7 +186,7 @@
 <t>Key points regarding the PDF output:</t>
 
 <t><list style='symbols'>
-  <t>The PDF file will not be derived from the plain-text publication format.</t>
+  <t>The PDF file will be rendered from the XML file; it will not be derived from the plain-text publication format.</t>
   <t>The PDF publication format will conform to the PDF/A-3 standard and will embed the canonical XML source.</t>
   <t>The PDF will look more like the HTML publication format than the plain-text publication format.</t>
   <t>The PDF will include a rich set of tags and metadata within the document</t>
@@ -259,7 +259,7 @@
 
 <t>Success will be measured by the closure of all bugs which had been identified by the RPC and the Tools Development team as fatal and consensus on the readiness of the XML vocabulary and final XML files for publication.  The actual rendering engine can go through further review and iteration, as the publication formats may be republished as needed.</t>
 
-<t>Authors are not required to submit their approved drafts in an XML format, though they are strongly encouraged to do so; plain-text will also remain an option for the foreseeable future.  However, documents submitted as plain-text cannot include such features as SVG artwork.</t>
+<t>Authors are not required to submit their approved drafts in an XML format, though they are strongly encouraged to do so; plain-text will also remain an option for the foreseeable future.  However, documents submitted as plain-text cannot include such features as SVG artwork. The RPC will generate an XML file if necessary for basic processing and subsequent rendering into the approved output formats.</t>
 
 <t>A known risk at this point of the transition is the difficulty in quantifying the resources required from the RPC.  This phase will require more work on the part of the RPC to support both old and new publication processes for at least six months.  There is potential for confusion as consumers of RFCs find some documents published at this time with a full set of outputs, while other documents only have plain text.  There may be a delay in publication as new bugs are found that must be fixed before the files can be converted into the canonical format and associated publication formats.</t>
 
@@ -290,6 +290,10 @@
 
 <section anchor="changelog" title="Appendix - Change log">
 <t>To be removed by RFC Editor</t>
+<section anchor="change04" title="draft-iab-rfc-framework-03 to -04">
+<t>Introduction: editorial changes</t>
+<t>Clarified that submitted plain text will be converted to XML by the RPC; the XML will be used to render all output formats. </t>
+</section>
 <section anchor="change03" title="draft-iab-rfc-framework-02 to -03">
 <t>HTML output: clarified expectations around use of JavaScript.
 </t>


### PR DESCRIPTION
Clarified that submitted plain text will be converted to XML by the
RPC; the XML will be used to render all output formats.
